### PR TITLE
Create .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,19 @@
+# We need to configure this via: https://github.com/guardian/scala-steward-public-repos
+# Default config settings are here: https://github.com/scala-steward-org/scala-steward/blob/c1aa49d38b3d5fa6adf63f59de240680d7f9135b/docs/repo-specific-configuration.md
+# Check if department-wide Scala Steward GitHub Action has broken on a team’s repo here: https://github.com/guardian/scala-steward-public-repos/actions/workflows/public-repos-scala-steward.yml
+
+# 10am Monday to Friday PR cron
+pullRequests.frequency = "0 10 * * 1-5"
+
+# Groups Scala Steward PRs together, in line with current DevX guidance (Server-side meetup - 1st February 2023)
+pullRequests.grouping = [
+  { name = "aws", "title" = "AWS dependency updates", "filter" = [{"group" = "software.amazon.awssdk"}, {"group" = "com.amazonaws"}] },
+  { name = "non_aws", "title" = "Non-AWS dependency updates", "filter" = [{"group" = "*"}] }
+]
+
+dependencyOverrides = [
+  {
+    dependency = { groupId = "software.amazon.awssdk" },
+    pullRequests = { frequency = "7 day" }
+  }
+]


### PR DESCRIPTION
Creating this PR after feedback in #6 - adds Scala Steward to this repo

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Are PRs relating to deps and sbt/scala versions generated every weekday at 10am and are they grouped by category i.e. AWS, non-AWS?

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
