### PR TITLE
Add error handling and unit tests

### DIFF
--- a/associated-press/app/config/AppConfig.scala
+++ b/associated-press/app/config/AppConfig.scala
@@ -9,7 +9,5 @@ class AppConfig(playConfig: Configuration) {
   val associatedPressAPIKey: String = config.getString("associatedPress.apiKey")
 
   val s3UploadEnabled: Boolean = config.getBoolean("aws.s3.uploadEnabled")
-  val s3UploadBucketName: String =
-    if(s3UploadEnabled) config.getString("aws.s3.uploadBucketName")
-    else throw UnexpectedException(Some("No configuration setting found for key 'aws.s3.uploadBucketName'"))
+  val s3UploadBucketName: String = if(s3UploadEnabled) config.getString("aws.s3.uploadBucketName") else ""
 }

--- a/associated-press/app/config/AppConfig.scala
+++ b/associated-press/app/config/AppConfig.scala
@@ -1,6 +1,6 @@
 package config
 
-import play.api.Configuration
+import play.api.{Configuration, UnexpectedException}
 
 class AppConfig(playConfig: Configuration) {
   private val config = playConfig.underlying
@@ -9,5 +9,7 @@ class AppConfig(playConfig: Configuration) {
   val associatedPressAPIKey: String = config.getString("associatedPress.apiKey")
 
   val s3UploadEnabled: Boolean = config.getBoolean("aws.s3.uploadEnabled")
-  val s3UploadBucketName: Option[String] = if(s3UploadEnabled) Option(config.getString("aws.s3.uploadBucketName")) else None
+  val s3UploadBucketName: String =
+    if(s3UploadEnabled) config.getString("aws.s3.uploadBucketName")
+    else throw UnexpectedException(Some("No configuration setting found for key 'aws.s3.uploadBucketName'"))
 }

--- a/associated-press/app/model/FeedResponse.scala
+++ b/associated-press/app/model/FeedResponse.scala
@@ -26,7 +26,8 @@ object FeedResponse extends Logging {
     jsValue match {
       case jsArray: JsArray =>
         jsArray.value.toArray
-          .filter(item => (item \ "item" \ "type").as[String] == "picture")
+          // some pictures do not have a main (full resolution) image defined, so we filter these items from the results
+          .filter(item => (item \ "item" \ "type").as[String] == "picture" && (item \ "item" \ "renditions" \ "main").toOption.isDefined)
           .map(item => ImageItem(
             contentId = (item \ "item" \ "altids" \ "itemid").as[String],
             fileName = (item \ "item" \ "renditions" \ "main" \ "originalfilename").as[String],

--- a/associated-press/app/model/FeedResponse.scala
+++ b/associated-press/app/model/FeedResponse.scala
@@ -9,8 +9,6 @@ case class FeedResponse(nextPage: String, items: Array[ImageItem])
 case class ImageItem(contentId: String, fileName: String, downloadLink: String)
 
 object FeedResponse extends Logging {
-  private implicit val itemFormat: OFormat[ImageItem] = Json.format[ImageItem]
-
   def parse(res: String): Option[FeedResponse] = Try {
     val json = Json.parse(res)
     FeedResponse(

--- a/associated-press/app/model/FeedResponse.scala
+++ b/associated-press/app/model/FeedResponse.scala
@@ -1,31 +1,40 @@
 package model
 
-import play.api.libs.json.JsResult.Exception
-import play.api.libs.json.{JsError, JsSuccess, Json, OFormat}
+import play.api.Logging
+import play.api.libs.json.{JsArray, JsValue, Json, OFormat}
 
-case class FeedResponse(data: Data)
-case class Data(next_page: String, items: Array[ItemMeta])
-case class ItemMeta(item: Item)
-case class Item(uri: String, altids: AltIds, renditions: Renditions)
-case class AltIds(friendlykey: String)
-case class Renditions(main: Main)
-case class Main(href: String, contentid: String)
+import scala.util.{Failure, Success, Try}
 
-object FeedResponse {
-  private implicit val mainFormat: OFormat[Main] = Json.format[Main]
-  private implicit val renditionsFormat: OFormat[Renditions] = Json.format[Renditions]
-  private implicit val altIdsFormat: OFormat[AltIds] = Json.format[AltIds]
-  private implicit val itemFormat: OFormat[Item] = Json.format[Item]
-  private implicit val itemMetaFormat: OFormat[ItemMeta] = Json.format[ItemMeta]
-  private implicit val dataFormat: OFormat[Data] = Json.format[Data]
-  private implicit val feedResponseFormat: OFormat[FeedResponse] = Json.format[FeedResponse]
+case class FeedResponse(nextPage: String, items: Array[ImageItem])
+case class ImageItem(contentId: String, fileName: String, downloadLink: String)
 
-  def parse(res: String): FeedResponse = {
-    Json.parse(res).validate[FeedResponse] match {
-      case feedResponse: JsSuccess[FeedResponse] => feedResponse.get
-      case error: JsError =>
-        // TODO: log and alert on parsing errors
-        throw Exception(error)
+object FeedResponse extends Logging {
+  private implicit val itemFormat: OFormat[ImageItem] = Json.format[ImageItem]
+
+  def parse(res: String): Option[FeedResponse] = Try {
+    val json = Json.parse(res)
+    FeedResponse(
+      nextPage = (json \ "data" \ "next_page").as[String],
+      items = (json \ "data" \ "items").toOption.map(getItemArrayFromJsValue).getOrElse(Array.empty)
+    )
+  } match {
+    case Success(response) => Some(response)
+    case Failure(error) =>
+      logger.error(s"Could not parse AP API response json", error)
+      None
+  }
+
+  private def getItemArrayFromJsValue(jsValue: JsValue): Array[ImageItem] = {
+    jsValue match {
+      case jsArray: JsArray =>
+        jsArray.value.toArray
+          .filter(item => (item \ "item" \ "type").as[String] == "picture")
+          .map(item => ImageItem(
+            contentId = (item \ "item" \ "altids" \ "itemid").as[String],
+            fileName = (item \ "item" \ "renditions" \ "main" \ "originalfilename").as[String],
+            downloadLink = (item \ "item" \ "renditions" \ "main" \ "href").as[String]
+          ))
+      case _ => Array.empty
     }
   }
 }

--- a/associated-press/app/model/FeedResponse.scala
+++ b/associated-press/app/model/FeedResponse.scala
@@ -26,8 +26,11 @@ object FeedResponse extends Logging {
     jsValue match {
       case jsArray: JsArray =>
         jsArray.value.toArray
-          // some pictures do not have a main (full resolution) image defined, so we filter these items from the results
-          .filter(item => (item \ "item" \ "type").as[String] == "picture" && (item \ "item" \ "renditions" \ "main").toOption.isDefined)
+          .filter(item =>
+            (item \ "item" \ "type").as[String] == "picture" &&
+            (item \ "item" \ "altids" \ "itemid").toOption.isDefined &&
+            (item \ "item" \ "renditions" \ "main" \ "originalfilename").toOption.isDefined &&
+            (item \ "item" \ "renditions" \ "main" \ "href").toOption.isDefined)
           .map(item => ImageItem(
             contentId = (item \ "item" \ "altids" \ "itemid").as[String],
             fileName = (item \ "item" \ "renditions" \ "main" \ "originalfilename").as[String],

--- a/associated-press/app/services/AssociatedPressService.scala
+++ b/associated-press/app/services/AssociatedPressService.scala
@@ -30,9 +30,7 @@ class AssociatedPressServiceActor(config: AppConfig, implicit val system: ActorS
   val imageUploaderServiceActor: ActorRef = system.actorOf(Props(new ImageUploaderService(config, executionContext)), name = "imageUploaderServiceActor")
 
   override def receive: Receive = {
-    case page:String =>
-      logger.info(s"Calling: $page")
-      get(page, Seq(("x-apikey", config.associatedPressAPIKey))).map(handleResponse)
+    case page:String => get(page, Seq(("x-apikey", config.associatedPressAPIKey))).map(handleResponse)
 
     def handleResponse(response: StandaloneWSResponse): Unit = {
       if(response.status == 200) {

--- a/associated-press/app/services/ImageUploaderService.scala
+++ b/associated-press/app/services/ImageUploaderService.scala
@@ -24,14 +24,12 @@ class ImageUploaderService(config: AppConfig, implicit val executionContext: Exe
 
     def uploadToS3(item: ImageItem, bytes: Array[Byte]):Unit = {
       if (config.s3UploadEnabled) {
-        config.s3UploadBucketName.map(bucket => {
           AWS.s3Client.putObject(PutObjectRequest.builder()
-            .bucket(bucket)
+            .bucket(config.s3UploadBucketName)
             .key(s"ap/${item.fileName}")
             .build(),
             RequestBody.fromBytes(bytes)
           )
-        })
       } else {
         logger.info(s"S3 upload disabled: would have uploaded image ${item.contentId}")
       }

--- a/associated-press/app/services/ImageUploaderService.scala
+++ b/associated-press/app/services/ImageUploaderService.scala
@@ -18,7 +18,7 @@ class ImageUploaderService(config: AppConfig, implicit val executionContext: Exe
         get(item.downloadLink, headers = Seq(("x-apikey", config.associatedPressAPIKey)))
           .map(response => {
             if (response.contentType == "image/jpeg") uploadToS3(item, response.bodyAsBytes.toArray)
-            else logger.warn(s"")
+            else logger.warn(s"Received response of type ${response.contentType}, content not processed")
           })
       )
 

--- a/associated-press/app/services/ImageUploaderService.scala
+++ b/associated-press/app/services/ImageUploaderService.scala
@@ -3,7 +3,7 @@ package services
 import akka.actor.Actor
 import client.HttpClient.get
 import config.{AWS, AppConfig}
-import model.ItemMeta
+import model.ImageItem
 import play.api.Logging
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -13,23 +13,28 @@ import scala.concurrent.ExecutionContext
 
 class ImageUploaderService(config: AppConfig, implicit val executionContext: ExecutionContext) extends Actor with Logging {
   override def receive: Receive = {
-    case items:Array[ItemMeta] =>
-      items.par.foreach(entry =>
-        get(entry.item.renditions.main.href, headers = Seq(("x-apikey", config.associatedPressAPIKey)))
+    case items:Array[ImageItem] =>
+      items.par.foreach(item =>
+        get(item.downloadLink, headers = Seq(("x-apikey", config.associatedPressAPIKey)))
           .map(response => {
-            if (response.contentType == "image/jpeg") {
-              if (config.s3UploadEnabled) {
-                config.s3UploadBucketName.map(bucket => {
-                  AWS.s3Client.putObject(PutObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(s"ap/${entry.item.altids.friendlykey}.jpg")
-                    .build(), RequestBody.fromBytes(response.bodyAsBytes.toArray))
-                })
-              } else {
-                logger.info(s"Would have uploaded image id ${entry.item.altids.friendlykey} with ${response.bodyAsBytes.size} bytes")
-              }
-            }
+            if (response.contentType == "image/jpeg") uploadToS3(item, response.bodyAsBytes.toArray)
+            else logger.warn(s"")
           })
       )
+
+    def uploadToS3(item: ImageItem, bytes: Array[Byte]):Unit = {
+      if (config.s3UploadEnabled) {
+        config.s3UploadBucketName.map(bucket => {
+          AWS.s3Client.putObject(PutObjectRequest.builder()
+            .bucket(bucket)
+            .key(s"ap/${item.fileName}")
+            .build(),
+            RequestBody.fromBytes(bytes)
+          )
+        })
+      } else {
+        logger.info(s"S3 upload disabled: would have uploaded image ${item.contentId}")
+      }
+    }
   }
 }

--- a/associated-press/test/model/FeedResponseTest.scala
+++ b/associated-press/test/model/FeedResponseTest.scala
@@ -1,0 +1,81 @@
+package model
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class FeedResponseTest extends AnyFunSuite with Matchers {
+  val nextPage = "https://api.ap.org/media/v2.2-preview/content/feed?qt=12345&seq=12345"
+  val downloadLink = "https://api.ap.org/media/v2.2-preview/content/12345/download"
+  val pictureItem: String = s"""{
+    "type": "picture",
+    "altids": {
+      "itemid": "12345"
+    },
+    "renditions": {
+      "main": {
+        "href": "$downloadLink",
+        "originalfilename": "name.jpg"
+      }
+    }
+  }""".stripMargin
+
+  test("should handle malformed json") {
+    val input = "not json"
+    FeedResponse.parse(input) should be(None)
+  }
+
+  test("should handle missing data") {
+    val input = "{}"
+    FeedResponse.parse(input) should be(None)
+  }
+
+  test("should extract next page url") {
+    val input =
+      s"""{
+        "data": {
+          "next_page": "$nextPage",
+          "items": []
+        }
+      }""".stripMargin
+    FeedResponse.parse(input).get.nextPage should be(nextPage)
+  }
+
+  test("should correctly parse a picture") {
+    val input =
+      s"""{
+        "data": {
+          "next_page": "$nextPage",
+          "items": [
+            {
+              "item": $pictureItem
+            }
+          ]
+        }
+      }""".stripMargin
+    val items = FeedResponse.parse(input).get.items
+    items.length should be(1)
+    items.head.downloadLink should be(downloadLink)
+  }
+
+  test("should filter non-image items") {
+    val input =
+      s"""{
+        "data": {
+          "next_page": "$nextPage",
+          "items": [
+            {
+              "item": $pictureItem
+            },
+            {
+              "item": {
+                "type": "text"
+              }
+            }
+          ]
+        }
+      }""".stripMargin
+    val items = FeedResponse.parse(input).get.items
+    items.length should be(1)
+    items.head.downloadLink should be(downloadLink)
+  }
+}

--- a/associated-press/test/model/FeedResponseTest.scala
+++ b/associated-press/test/model/FeedResponseTest.scala
@@ -78,4 +78,27 @@ class FeedResponseTest extends AnyFunSuite with Matchers {
     items.length should be(1)
     items.head.downloadLink should be(downloadLink)
   }
+
+  test("should filter images without a main image") {
+    val input =
+      s"""{
+        "data": {
+          "next_page": "$nextPage",
+          "items": [
+            {
+              "item": {
+                "type": "picture",
+                "altids": {
+                  "itemid": "12345"
+                },
+                "renditions": {
+                  "caption_nitf": {}
+                }
+              }
+            }
+          ]
+        }
+      }""".stripMargin
+    FeedResponse.parse(input).get.items.length should be(0)
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,12 @@ lazy val associatedPressFeed = Project("associated-press-feed", file("associated
     name := "associated-press-feed",
     ThisBuild / scalaVersion := scalaVersionSpec,
     libraryDependencies ++= Seq(
+      ws,
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
       "software.amazon.awssdk" % "s3" % "2.19.32",
       "com.gu" %% "simple-configuration-ssm" % "1.5.7",
-      ws
+      "org.scalatest" %% "scalatest" % "3.2.15" % "test",
+      "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
     ),
     routesGenerator := InjectedRoutesGenerator,
     PlayKeys.playDefaultPort := 8855

--- a/build.sbt
+++ b/build.sbt
@@ -9,10 +9,9 @@ lazy val associatedPressFeed = Project("associated-press-feed", file("associated
     libraryDependencies ++= Seq(
       ws,
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4",
-      "software.amazon.awssdk" % "s3" % "2.19.32",
+      "software.amazon.awssdk" % "s3" % "2.20.3",
       "com.gu" %% "simple-configuration-ssm" % "1.5.7",
       "org.scalatest" %% "scalatest" % "3.2.15" % "test",
-      "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
     ),
     routesGenerator := InjectedRoutesGenerator,
     PlayKeys.playDefaultPort := 8855


### PR DESCRIPTION
## What does this change?
This improves the error handling for JSON parsing errors and also introduces retries if we receive a non-200 response from AP's API. If you want to see the images end up in the grid, you can change `uploadEnabled` in local config to `true` and hit the healthcheck endpoint to start the app in DEV mode.

## How to test
Run this app locally and hit the healthcheck endpoint, does everything work as expected? Run the unit tests, do they pass?