### PR TITLE
Enable nightly backups for associated-press-feed's table

### DIFF
--- a/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
+++ b/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
@@ -1014,6 +1014,10 @@ exports[`The AssociatedPressFeed stack matches the snapshot 1`] = `
         "TableName": "associated-press-feed-TEST",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/associated-press/cdk/lib/associated-press-feed.ts
+++ b/associated-press/cdk/lib/associated-press-feed.ts
@@ -3,7 +3,7 @@ import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import type { App } from 'aws-cdk-lib';
-import { Fn } from 'aws-cdk-lib';
+import { Fn, Tags } from 'aws-cdk-lib';
 import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 
@@ -21,6 +21,9 @@ export class AssociatedPressFeed extends GuStack {
 			readCapacity: 50,
 			writeCapacity: 50
 		});
+
+		// Enable automated backups via https://github.com/guardian/aws-backup
+		Tags.of(nextPageTable).add("devx-backup-enabled", "true");
 
 		new GuPlayWorkerApp(this, {
 			app: props.app ?? 'associated-press-feed',


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up `associated-press-feed`'s DynamoDB table using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering & EMs.

## How to test

I think that snapshot testing is sufficient here.

I will also double check that backups are taken as expected (this should happen the night after this CFN change is applied).

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is ever deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

## Deployment

[Riff-Raff deploys this infrastructure](https://github.com/guardian/grid-feeds/blob/6a1739aad739ebf760aa51052401b3613f13ab08/riff-raff.yaml) and [CD is enabled](https://riffraff.gutools.co.uk/deployment/continuous/9182db10-74a8-4f4b-baeb-460b2584a600/edit), so merging this PR should be sufficient.