### PR TITLE
write the grid ingest bucket name from CDK into param store config

### DIFF
--- a/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
+++ b/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
@@ -198,6 +198,43 @@ exports[`The AssociatedPressFeed stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GridIngestBucketName7D914517": {
+      "Properties": {
+        "Description": "The s3 bucket name to upload images to. [AUTOMATICALLY UPDATED FROM CDK/CFN]",
+        "Name": "/TEST/media-service/associated-press-feed/aws/s3/uploadBucketName",
+        "Tags": {
+          "Stack": "media-service",
+          "Stage": "TEST",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/grid-feeds",
+        },
+        "Type": "String",
+        "Value": {
+          "Fn::Select": [
+            0,
+            {
+              "Fn::Split": [
+                "/",
+                {
+                  "Fn::Select": [
+                    5,
+                    {
+                      "Fn::Split": [
+                        ":",
+                        {
+                          "Fn::ImportValue": "IngestQueueBucketArn-TEST",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "GuHttpsEgressSecurityGroupAssociatedpressfeed087368CF": {
       "Properties": {
         "GroupDescription": "Allow all outbound HTTPS traffic",


### PR DESCRIPTION
#32 didn't work right away - resulted in `Access Denied` exceptions in PROD) because we didn't update the config but the PR did change the IAM permissions. 
This avoids that manual config updating by writing the bucket name from CDK into the relevant param store property (required deleting the config property first, to allow CDK/CFN to recreate it)