### PR TITLE
TEMPORARY FOR XMAS BREAK - use S3 watcher bucket for grid ingest

### DIFF
--- a/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
+++ b/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
@@ -222,7 +222,7 @@ exports[`The AssociatedPressFeed stack matches the snapshot 1`] = `
                       "Fn::Split": [
                         ":",
                         {
-                          "Fn::ImportValue": "IngestQueueBucketArn-TEST",
+                          "Fn::ImportValue": "S3WatcherIngestBucketARN-TEST",
                         },
                       ],
                     },
@@ -1255,7 +1255,7 @@ dpkg -i /associated-press-feed/associated-press-feed.deb",
                   "",
                   [
                     {
-                      "Fn::ImportValue": "IngestQueueBucketArn-TEST",
+                      "Fn::ImportValue": "S3WatcherIngestBucketARN-TEST",
                     },
                     "/ap/*",
                   ],

--- a/associated-press/cdk/lib/associated-press-feed.ts
+++ b/associated-press/cdk/lib/associated-press-feed.ts
@@ -14,7 +14,7 @@ export class AssociatedPressFeed extends GuStack {
 		super(scope, id, props);
 
 		const gridIngestBucketArn = Fn.importValue(
-			`IngestQueueBucketArn-${props.stage === 'PROD' ? 'PROD' : 'TEST'}`,
+			`S3WatcherIngestBucketARN-${props.stage === 'PROD' ? 'PROD' : 'TEST'}`,
 		);
 
 		const gridIngestBucket = s3.Bucket.fromBucketArn(this, 'gridIngestBucket', gridIngestBucketArn);


### PR DESCRIPTION
Co-authored-by: @dblatcher 

As per https://trello.com/c/5NchFBNj/1947-phased-switchover-of-grid-ftp-to-queue-based-ingestion we've been ramping up to 100% of images (UI, FTP, SFTP & grid-feeds) using the [new queue-based ingestion](https://github.com/guardian/grid/pull/4201) with good results 🎉  - as planned though we want to revert back to everything via S3 watcher over the xmas break (for peace of mind, 24/7 etc.) with the confidence to flick back to all queue-based first thing in 2024. **This PR switches the bucket back to use the S3 watcher bucket (i.e. push-based mechanism).**