### PR TITLE
Revert "TEMPORARY FOR XMAS BREAK - use S3 watcher bucket for grid ingest"

### DIFF
--- a/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
+++ b/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
@@ -222,7 +222,7 @@ exports[`The AssociatedPressFeed stack matches the snapshot 1`] = `
                       "Fn::Split": [
                         ":",
                         {
-                          "Fn::ImportValue": "S3WatcherIngestBucketARN-TEST",
+                          "Fn::ImportValue": "IngestQueueBucketArn-TEST",
                         },
                       ],
                     },
@@ -1255,7 +1255,7 @@ dpkg -i /associated-press-feed/associated-press-feed.deb",
                   "",
                   [
                     {
-                      "Fn::ImportValue": "S3WatcherIngestBucketARN-TEST",
+                      "Fn::ImportValue": "IngestQueueBucketArn-TEST",
                     },
                     "/ap/*",
                   ],

--- a/associated-press/cdk/lib/associated-press-feed.ts
+++ b/associated-press/cdk/lib/associated-press-feed.ts
@@ -14,7 +14,7 @@ export class AssociatedPressFeed extends GuStack {
 		super(scope, id, props);
 
 		const gridIngestBucketArn = Fn.importValue(
-			`S3WatcherIngestBucketARN-${props.stage === 'PROD' ? 'PROD' : 'TEST'}`,
+			`IngestQueueBucketArn-${props.stage === 'PROD' ? 'PROD' : 'TEST'}`,
 		);
 
 		const gridIngestBucket = s3.Bucket.fromBucketArn(this, 'gridIngestBucket', gridIngestBucketArn);


### PR DESCRIPTION
Reverts guardian/grid-feeds#34 to effectively re-instate #32 now we're back from xmas break (and worked nicely before).