### PR TITLE
Upgrade to Play 3.0

### DIFF
--- a/associated-press/app/client/HttpClient.scala
+++ b/associated-press/app/client/HttpClient.scala
@@ -1,6 +1,6 @@
 package client
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 import play.api.libs.ws.StandaloneWSResponse
 import play.api.libs.ws.ahc.StandaloneAhcWSClient
 

--- a/associated-press/app/services/AssociatedPressService.scala
+++ b/associated-press/app/services/AssociatedPressService.scala
@@ -1,7 +1,7 @@
 package services
 
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.stream.Materializer
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.stream.Materializer
 import client.HttpClient.get
 import config.AWS.{readFromDynamoDB, writeToDynamoDB}
 import config.AppConfig

--- a/associated-press/app/services/ImageUploaderService.scala
+++ b/associated-press/app/services/ImageUploaderService.scala
@@ -1,6 +1,6 @@
 package services
 
-import akka.actor.Actor
+import org.apache.pekko.actor.Actor
 import client.HttpClient.get
 import config.{AWS, AppConfig}
 import model.ImageItem

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.5")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.5")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.13")
 


### PR DESCRIPTION
Upgrades to the latest Play v3 - requires just updating the version number and switching to Pekko imports