### PR TITLE
Forcibly upgrade all downloads to HTTPS

### DIFF
--- a/associated-press/app/client/HttpClient.scala
+++ b/associated-press/app/client/HttpClient.scala
@@ -16,7 +16,11 @@ object HttpClient {
       headers: Seq[(String, String)] = Seq.empty,
       parameters: Seq[(String, String)] = Seq.empty
   ): Future[StandaloneWSResponse] = {
-    ws.url(uri)
+    // on the CODE env, the preview feed will return HTTP S3 URLs, but our
+    // security group only allows outbound requests on port 443...
+    // force all the URIs to HTTPS to allow the requests to complete.
+    val forcedHttps = uri.replaceAll("^http://", "https://")
+    ws.url(forcedHttps)
       .addHttpHeaders(headers: _*)
       .addQueryStringParameters(parameters: _*)
       .get()


### PR DESCRIPTION
## What does this change?

Everything should be using HTTPS anyway, except that download links returned in the preview feed point to an HTTP S3 URL, and our security group blocks HTTP/port 80 so connections hang and timeout. Upgrade all connections to HTTPS instead.

<img width="949" alt="image" src="https://github.com/user-attachments/assets/e9abfab8-8d7e-494e-a470-3e32dbfb72da">

## How to test

Deploy to CODE, and see the quantity of timeout exceptions drop, hopefully to 0.
