### PR TITLE
switch ap feed table to ondemand pricing

### DIFF
--- a/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
+++ b/associated-press/cdk/lib/__snapshots__/associated-press-feed.test.ts.snap
@@ -1127,16 +1127,13 @@ exports[`The AssociatedPressFeed stack matches the snapshot 1`] = `
             "AttributeType": "S",
           },
         ],
+        "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
             "AttributeName": "key",
             "KeyType": "HASH",
           },
         ],
-        "ProvisionedThroughput": {
-          "ReadCapacityUnits": 50,
-          "WriteCapacityUnits": 50,
-        },
         "TableName": "associated-press-feed-TEST",
         "Tags": [
           {

--- a/associated-press/cdk/lib/associated-press-feed.ts
+++ b/associated-press/cdk/lib/associated-press-feed.ts
@@ -4,9 +4,9 @@ import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuAllowPolicy } from '@guardian/cdk/lib/constructs/iam';
 import type { App } from 'aws-cdk-lib';
 import { Fn, Tags } from 'aws-cdk-lib';
-import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
-import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
 import {StringParameter} from "aws-cdk-lib/aws-ssm";
 
 export class AssociatedPressFeed extends GuStack {
@@ -17,7 +17,7 @@ export class AssociatedPressFeed extends GuStack {
 			`IngestQueueBucketArn-${props.stage === 'PROD' ? 'PROD' : 'TEST'}`,
 		);
 
-		const gridIngestBucket = s3.Bucket.fromBucketArn(this, 'gridIngestBucket', gridIngestBucketArn);
+		const gridIngestBucket = Bucket.fromBucketArn(this, 'gridIngestBucket', gridIngestBucketArn);
 
 		const {stage, stack, app} = props;
 		new StringParameter(this, "GridIngestBucketName", {
@@ -29,8 +29,7 @@ export class AssociatedPressFeed extends GuStack {
 		const nextPageTable = new Table(this, 'associatedPressFeedNextPageTable', {
 			partitionKey: { name: 'key', type: AttributeType.STRING },
 			tableName: `${props.app ?? 'associated-press-feed'}-${props.stage}`,
-			readCapacity: 50,
-			writeCapacity: 50
+			billingMode: BillingMode.PAY_PER_REQUEST,
 		});
 
 		// Enable automated backups via https://github.com/guardian/aws-backup


### PR DESCRIPTION
throughput is massively overprovisioned, we have fractions of a unit of usage but provision for 50...

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
