### PR TITLE
correct the resumption fetch from dynamo

### DIFF
--- a/associated-press/app/config/AWS.scala
+++ b/associated-press/app/config/AWS.scala
@@ -84,7 +84,7 @@ object AWS {
       table: String,
       keyName: String,
       keyValue: String
-  ): Try[Iterable[String]] = {
+  ): Try[Option[String]] = {
     Try {
       dynamoDbClient
         .getItem(
@@ -99,9 +99,9 @@ object AWS {
             .build()
         )
         .item()
-        .values()
         .asScala
-        .map(value => value.s())
+        .get("nextPage")
+        .map(_.s())
     }
   }
 }

--- a/associated-press/app/services/AssociatedPressService.scala
+++ b/associated-press/app/services/AssociatedPressService.scala
@@ -31,7 +31,7 @@ class AssociatedPressService(
   private def getFirstPageUrl: String = {
     readFromDynamoDB(config.dynamoDBNextPageTable, "key", "nextPage") match {
       case Success(values) =>
-        values.headOption.getOrElse(config.associatedPressAPIDefaultFeedUrl)
+        values.getOrElse(config.associatedPressAPIDefaultFeedUrl)
       case Failure(e) =>
         logger.error(
           "Failed to retrieve first page from dynamoDB, using default url instead",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Previously, when grid-feeds would resume from a previous run, fetching the nextPage from the table, it would turn all the values for the row into their string value, and attempt to use the first (from an unordered collection) as the url for the next page. But there are two columns in the table - the `id` and the `nextPage`. This means that the logic has a 50% chance of picking the `id` column (which contains the constant value `"nextPage"`, not to be confused with the `nextPage` column!) to attempt to use as the URL, which will fail as `"nextPage"` is not a valid URL: `java.lang.IllegalArgumentException: Invalid URL nextPage`

Instead, intentionally select the value of the `nextPage` column to use as the URL, which should increase success rate when resuming.