### PR TITLE
handle redirects ourselves and force them into HTTPS, to work nicer in CODE

### DIFF
--- a/associated-press/app/client/HttpClient.scala
+++ b/associated-press/app/client/HttpClient.scala
@@ -11,18 +11,38 @@ object HttpClient {
   implicit val system: ActorSystem = ActorSystem()
   lazy val ws: StandaloneAhcWSClient = StandaloneAhcWSClient()
 
+  private val MAX_RECURSIONS = 5
+
   def get(
       uri: String,
       headers: Seq[(String, String)] = Seq.empty,
-      parameters: Seq[(String, String)] = Seq.empty
+      parameters: Seq[(String, String)] = Seq.empty,
+      recursions: Int = 0
   ): Future[StandaloneWSResponse] = {
+    if (recursions > MAX_RECURSIONS) {
+      throw new IllegalArgumentException(
+        s"request has redirected too many times; latest was to $uri"
+      )
+    }
     // on the CODE env, the preview feed will return HTTP S3 URLs, but our
     // security group only allows outbound requests on port 443...
     // force all the URIs to HTTPS to allow the requests to complete.
     val forcedHttps = uri.replaceAll("^http://", "https://")
-    ws.url(forcedHttps)
+    val request = ws
+      .url(forcedHttps)
       .addHttpHeaders(headers: _*)
       .addQueryStringParameters(parameters: _*)
+      .withFollowRedirects(false)
       .get()
+
+    request.flatMap(response => {
+      response.header("Location") match {
+        // manage redirects ourselves, to send the new location through the forcedHttps above
+        case Some(redirect)
+            if response.status >= 300 || response.status < 400 =>
+          get(redirect, headers, recursions = recursions + 1)
+        case _ => Future.successful(response)
+      }
+    })(system.dispatcher)
   }
 }


### PR DESCRIPTION
CODE env download links are redirects to `http://s3.amazonaws.com/...` - but we require outbound requests are 443/HTTPS only. Disable the automatic redirection following behaviour in play-ws, and handle them ourselves, upgrading to HTTPS manually.